### PR TITLE
Detect and use current package.json indentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "chalk": "^2.4.2",
     "command-exists": "^1.2.8",
     "commander": "^2.20.0",
+    "detect-indent": "^6.0.0",
     "figures": "^3.0.0",
     "pacote": "^9.5.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -330,6 +330,11 @@ deglob@^3.0.0:
     run-parallel "^1.1.2"
     uniq "^1.0.1"
 
+detect-indent@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-6.0.0.tgz#0abd0f549f69fc6659a254fe96786186b6f528fd"
+  integrity sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA==
+
 doctrine@1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"


### PR DESCRIPTION
Currently `2` spaces are _always_ used. This change detects the current indent, e.g doesn't change or overrides the current one :) (I myself use always 4 spaces, so this fix should be an all-rounder)